### PR TITLE
Always track visits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+test/reports

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in ahoy.gemspec
 gemspec
+
+group :test do
+  gem 'minitest-ci',               git: 'git@github.com:circleci/minitest-ci.git'
+end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 ### This is littleBit's forked version of Ahoy. Please refer to our own tracking [wiki](https://github.com/littlebitselectronics/little_bits/wiki/Tracking-and-AB-testing) to understand how Ahoy interfaces with our application and what methods to use for tracking
 
+[![Circle CI](https://circleci.com/gh/littlebitselectronics/ahoy.svg?style=svg)](https://circleci.com/gh/littlebitselectronics/ahoy)
+[![Code Climate](https://codeclimate.com/github/littlebitselectronics/ahoy/badges/gpa.svg)](https://codeclimate.com/github/littlebitselectronics/ahoy)
+
 # Ahoy
+
 
 Ahoy provides a solid foundation to track visits and events in Ruby, JavaScript, and native apps.
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  ruby:
+    version: 2.1.5

--- a/lib/ahoy/controller.rb
+++ b/lib/ahoy/controller.rb
@@ -28,12 +28,12 @@ module Ahoy
       delete_obsolete_cookies
     end
 
+    # We can avoid calling visitor_id and visit_id here since the
+    # store has access to the same two methods
+    # TODO: track_visit the whole time, and let the store decide when to store
+    # similar ones or handle them differently
     def track_ahoy_visit
-      if ahoy.new_visit?
-        ahoy.track_visit(defer: !Ahoy.track_visits_immediately)
-      else
-        ahoy.check_for_persistence(visitor_id: ahoy.visitor_id, visit_id: ahoy.visit_id)
-      end
+      ahoy.track_visit(defer: !Ahoy.track_visits_immediately)
     end
 
     private

--- a/lib/ahoy/controller.rb
+++ b/lib/ahoy/controller.rb
@@ -28,10 +28,6 @@ module Ahoy
       delete_obsolete_cookies
     end
 
-    # We can avoid calling visitor_id and visit_id here since the
-    # store has access to the same two methods
-    # TODO: track_visit the whole time, and let the store decide when to store
-    # similar ones or handle them differently
     def track_ahoy_visit
       ahoy.track_visit(defer: !Ahoy.track_visits_immediately)
     end

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -35,6 +35,7 @@ module Ahoy
           set_cookie("ahoy_track", true)
         else
           options = options.dup
+          options.merge!(new_visit: new_visit?)
 
           @store.track_visit(options) do |visit|
             persisted_visit = visit

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -46,35 +46,6 @@ module Ahoy
       report_exception(e)
     end
 
-    def check_for_persistence(options = {})
-      visit = Visit.find_by(id: options[:visit_id])
-
-      if visit.nil?
-        visit = self.track_visit
-
-        if visit.nil?
-          ::Honeybadger.notify(
-            :error_class   => "Ahoy::Tracker#check_for_persistence",
-            :error_message => "Visit nil and unable to be created",
-            :parameters    => {
-              visit_id: options[:visit_id],
-              visitor_id: options[:visitor_id]
-            }
-          )
-        else
-          ::Honeybadger.notify(
-            :error_class   => "Ahoy::Tracker#check_for_persistence",
-            :error_message => "Visit was succesfully created",
-            :parameters    => {
-              visit_id: options[:visit_id],
-              visit: visit,
-              visitor_id: options[:visitor_id]
-            }
-          )
-        end
-      end
-    end
-
     def authenticate(user)
       unless exclude?
         @store.authenticate(user)

--- a/test/ahoy_controller_test.rb
+++ b/test/ahoy_controller_test.rb
@@ -1,0 +1,23 @@
+require_relative 'test_helper'
+
+class TestAhoyController < Minitest::Test
+  def setup
+    controller_class = Class.new
+    def controller_class.helper_method(_method_name); end
+
+    def controller_class.before_filter(*_method_name); end
+    controller_class.include(Ahoy::Controller)
+
+    @controller = controller_class.new
+  end
+
+  def test_track_ahoy_visit
+    @mock_tracker = Minitest::Mock.new
+    @mock_tracker.expect(:track_visit, nil, [{ defer: true }])
+    @controller.instance_variable_set('@ahoy', @mock_tracker)
+
+    @controller.track_ahoy_visit
+
+    @mock_tracker.verify
+  end
+end

--- a/test/ahoy_tracker_test.rb
+++ b/test/ahoy_tracker_test.rb
@@ -1,0 +1,50 @@
+require_relative 'test_helper'
+
+class Ahoy::Store < Ahoy::Stores::BaseStore
+  # The visit_tracker options is for testing purposes only.
+  # It helps to inject a mock for whom we set expectations.
+  def initialize(options)
+    super(options)
+
+    @visit_tracker = options[:visit_tracker]
+  end
+
+  def track_visit(options)
+    @visit_tracker.track_visit(options)
+  end
+end
+
+
+class TestAhoyTracker < Minitest::Test
+  def setup
+    @mock_request = MiniTest::Mock.new
+    @mock_request.expect(:subdomain, nil)
+    @mock_request.expect(:domain, 'domain')
+    @mock_request.expect(:user_agent, 'chrome')
+    @mock_request.expect(:headers, {})
+
+    @mock_visit_tracker = MiniTest::Mock.new
+
+    @tracker = Ahoy::Tracker.new(request: @mock_request,
+                                 visit_tracker: @mock_visit_tracker)
+  end
+
+  def test_track_visit_when_not_visit
+    @mock_request.expect(:cookies, { 'visit' => 'whatever' })
+    @mock_visit_tracker.expect(:track_visit, true, [ { new_visit: false } ])
+
+    @tracker.track_visit
+
+    @mock_visit_tracker.verify
+  end
+
+  def test_track_visit_when_new_visit
+    @mock_request.expect(:cookies, {})
+    @mock_visit_tracker.expect(:track_visit, true, [ { new_visit: true } ])
+
+    @tracker.track_visit
+
+    @mock_visit_tracker.verify
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
-require "bundler/setup"
+require 'bundler/setup'
 Bundler.require(:default, :test)
-require "minitest/autorun"
-require "minitest/pride"
+require 'minitest/autorun'
+require 'minitest/pride'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
 require "bundler/setup"
-Bundler.require(:default)
+Bundler.require(:default, :test)
 require "minitest/autorun"
 require "minitest/pride"

--- a/test/visit_properties_test.rb
+++ b/test/visit_properties_test.rb
@@ -1,4 +1,4 @@
-require_relative "test_helper"
+require_relative 'test_helper'
 
 class TestVisitProperties < Minitest::Test
   def setup


### PR DESCRIPTION
- Remove Ahoy::Tracker#check_for_persistance behavior, it can be
  implemented via a custom store
- Always track visits, let store decide what to do with them.
